### PR TITLE
make prefix currency symbol default and define override for postfix

### DIFF
--- a/src/invoice.cls
+++ b/src/invoice.cls
@@ -85,6 +85,14 @@
     \def\@vat{#1}%
 }
 
+% Toggle whether the currency symbol should appear after the amount
+%
+% usage: \currencysymbolpostfix
+\newtoggle{@postfixcurrencysymbol}
+\newcommand*{\currencysymbolpostfix}{%
+  \toggletrue{@postfixcurrencysymbol}%
+}
+
 % Define currency
 %
 % usage: \currency{<currency_code>}{<currency_symbol>}
@@ -92,12 +100,12 @@
     \def\@currencycode{#1}
     \def\@currencysymbol{#2}
 
-    \ifthenelse{\equal{#2}{\$}}{
-        \def\@currencybeforesymbol{#2 }
-        \def\@currencyaftersymbol{}
-    }{
+    \iftoggle{@postfixcurrencysymbol}{
         \def\@currencybeforesymbol{}
         \def\@currencyaftersymbol{ #2}
+    }{
+        \def\@currencybeforesymbol{#2 }
+        \def\@currencyaftersymbol{}
     }
 }
 


### PR DESCRIPTION
It's not just the US Dollar that has its symbol printed before the amount (£, Pound Sterling for example). Instead of trying to decide the behavior based on the symbol, I've defined a command that would allow the user to specify whether they want the amount to be prefixed or postfixed with the symbol.
